### PR TITLE
Bug 1008934: a more responsive UI for mobile & desktop

### DIFF
--- a/content/css/webapp.css
+++ b/content/css/webapp.css
@@ -2,10 +2,35 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-body {
-  width: 100%;
-  /* prevent the video convsersation elements to occupy the whole available
-     width hence the height while keeping aspect ratio */
-  max-width: 730px;
-  margin: 0 auto;
+.conversation-form {
+  text-align: center;
+}
+
+.conversation-form .btn {
+  position: absolute;
+  top: 45%;
+  width: 10em;
+  margin-left: -5em;
+  height: 2.5em;
+  font-size: 1.4em;
+}
+
+/* Landscape */
+@media screen and (orientation:landscape) {
+  .conversation {
+    max-height: 100vh;
+    overflow: hidden;
+  }
+
+  .conversation .media.nested .remote {
+    width: 100%;
+    max-height: 90vh;
+    overflow: hidden;
+  }
+
+  .conversation .media.nested .remote video {
+    -moz-transform: scale(1.5);
+    transform: scale(1.5);
+    margin-top: -20%;
+  }
 }

--- a/content/index.html
+++ b/content/index.html
@@ -6,16 +6,13 @@
   <head>
     <meta charset="utf-8">
     <title>Loop</title>
+    <meta name="viewport" content="initial-scale=1, maximum-scale=1">
     <link rel="stylesheet" type="text/css" href="shared/css/common.css">
     <link rel="stylesheet" type="text/css" href="shared/css/conversation.css">
     <link rel="stylesheet" type="text/css" href="css/webapp.css">
     <link rel="prefetch" type="application/l10n" href="l10n/data.ini">
   </head>
   <body onload="loop.webapp.init();">
-
-    <header>
-      <h1>Loop</h1>
-    </header>
 
     <div id="messages"></div>
 

--- a/content/js/webapp.js
+++ b/content/js/webapp.js
@@ -40,7 +40,7 @@ loop.webapp = (function($, _, OT) {
    */
   var ConversationFormView = sharedViews.BaseView.extend({
     template: _.template([
-      '<form>',
+      '<form class="conversation-form">',
       '  <p>',
       '    <button class="btn btn-success" data-l10n-id="start_call"></button>',
       '  </p>',


### PR DESCRIPTION
Related bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1008934

_Hint: “Démarrer l'appel” is French for “Start call”._

Start page, portrait on mobile:

![screen shot 2014-05-13 at 16 26 35](https://cloud.githubusercontent.com/assets/41547/2958634/622b409e-daab-11e3-9a77-1dba7ef4480b.png)

Start page, landscape on mobile:

![screen shot 2014-05-13 at 16 26 41](https://cloud.githubusercontent.com/assets/41547/2958640/7028777a-daab-11e3-82f0-1b4312347d43.png)

Conversation, portrait on mobile:

![screen shot 2014-05-13 at 16 25 06](https://cloud.githubusercontent.com/assets/41547/2958657/82ae12ba-daab-11e3-9414-0e2e39325146.png)

Conversation, landscape on mobile:

![screen shot 2014-05-13 at 16 24 58](https://cloud.githubusercontent.com/assets/41547/2958659/8b68e7a4-daab-11e3-92a2-e047c66e13b8.png)

Start page, desktop:

![screen shot 2014-05-13 at 16 26 21](https://cloud.githubusercontent.com/assets/41547/2958663/9a04c940-daab-11e3-829e-759a7a1d3c2f.png)

Conversation, desktop:

![screen shot 2014-05-13 at 16 25 44](https://cloud.githubusercontent.com/assets/41547/2958664/a14d43b2-daab-11e3-93b0-8b664e7f74e5.png)
