### PR TITLE
Adding ESLint to help lint JSDoc comments

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+content/shared/libs/**
+test/shared/vendor/**

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,101 @@
+# http://eslint.org/docs/rules/
+
+env:
+  "amd": true
+  "browser": true
+  "mocha": true
+  "node": true
+
+globals:
+  $: false
+  _: false
+  Backbone: false
+  chai: false
+  jQuery: false
+
+rules:
+  "no-alert": 2
+  "no-array-constructor": 2
+  "no-bitwise": 1
+  "no-caller": 2
+  "no-catch-shadow": 2
+  "no-comma-dangle": 2
+  "no-console": 0
+  "no-control-regex": 2
+  "no-debugger": 2
+  "no-delete-var": 2
+  "no-div-regex": 2
+  "no-dupe-keys": 2
+  "no-else-return": 0
+  "no-empty": 2
+  "no-empty-class": 2
+  "no-empty-label": 2
+  "no-eq-null": 2
+  "no-eval": 2
+  "no-ex-assign": 2
+  "no-fallthrough": 2
+  "no-floating-decimal": 2
+  "no-func-assign": 2
+  "no-global-strict": 0
+  "no-implied-eval": 2
+  "no-iterator": 2
+  "no-label-var": 2
+  "no-loop-func": 2
+  "no-mixed-requires": [0, false]
+  "no-multi-str": 2
+  "no-native-reassign": 2
+  "no-new": 2
+  "no-new-func": 2
+  "no-new-object": 2
+  "no-new-wrappers": 2
+  "no-obj-calls": 2
+  "no-octal": 2
+  "no-octal-escape": 2
+  "no-plusplus": 0
+  "no-proto": 2
+  "no-redeclare": 2
+  "no-regex-spaces": 2
+  "no-return-assign": 2
+  "no-script-url": 2
+  "no-self-compare": 2
+  "no-shadow": 2
+  "no-sync": 0
+  "no-ternary": 0
+  "no-undef": 2
+  "no-undef-init": 2
+  "no-underscore-dangle": 0
+  "no-unreachable": 2
+  "no-unused-expressions": 1
+  "no-unused-vars": 1
+  "no-use-before-define": 0
+  "no-with": 2
+  "no-wrap-func": 2
+  "no-yoda": 0
+
+  "block-scoped-var": 0
+  "brace-style": 0
+  "camelcase": 0
+  "complexity": [0, 11]
+  "consistent-return": 0
+  "consistent-this": [0, "that"]
+  "curly": 0
+  "dot-notation": 0
+  "eqeqeq": 2
+  "guard-for-in": 0
+  "max-depth": [0, 4]
+  "max-len": [1, 80, 4]
+  "max-params": [0, 3]
+  "max-statements": [0, 10]
+  "new-cap": 2
+  "new-parens": 2
+  "one-var": 0
+  "quote-props": 0
+  "quotes": [0, "single"]
+  "radix": 0
+  "semi": 0
+  "strict": 0
+  "unnecessary-strict": 0
+  "use-isnan": 2
+  "valid-jsdoc": [2, {"requireReturn": false}]
+  "wrap-iife": 0
+  "wrap-regex": 0

--- a/package.json
+++ b/package.json
@@ -5,19 +5,23 @@
   "author": "Mozilla (https://mozilla.org/)",
   "engines": {
     "node": "0.10.x",
-    "npm":"1.3.x"
+    "npm": "1.3.x"
   },
   "dependencies": {
     "express": "3.x"
   },
   "devDependencies": {
+    "eslint": "0.6.x",
     "jshint": "2.x"
   },
   "scripts": {
     "test": "make test",
-    "start": "make runserver"
+    "start": "make runserver",
+    "eslint": "eslint *.js content/ test/"
   },
-  "keywords": ["webrtc"],
+  "keywords": [
+    "webrtc"
+  ],
   "license": "MPL-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
... In case anybody is interested in an ESLint vs JSHint debate.

We can tweak the .eslintrc rules to kill anything we don't want to enforce, or I can find the ESLint syntax to ignore specific rules per block/line since we're getting a few errors on long URLs in doc comments. :meh:

There isn't much reason to use both JSHint _**AND**_ ESLint, so we can probably remove the former if we want to go w/ ESLint.
