### PR TITLE
Bug 1050295 - The extraction script should update the changelog automatically

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,13 @@ Changelog
 
 This document describes changes between each past release.
 
+Note to release creators: Please ensure that on master there is always a
+                          "TBD\n---\n\n" section at the start, followed by
+                          the section of the previous release in
+                          "<version> (<date>)\n---\n\n" format. This ensures
+                          that extract_from_hg.py can find where to insert
+                          entries automatically.
+
 TBD
 -------------------
 


### PR DESCRIPTION
This extends the script to format and write the changesets into the changelog. The formatting possibly isn't 100% perfect, but it at least does most of the work which should mean the changelog just needs minor corrections now and again at release time.
